### PR TITLE
Fix buffer overflow from stdin

### DIFF
--- a/src/psh.cpp
+++ b/src/psh.cpp
@@ -19,7 +19,7 @@ int main()
         std::cout << std::endl << PURPLE_FOREGROUND << "○ " << std::getenv("USER") << BLUE_FOREGROUND << "→" << RESET <<" ";
 
         // Read the user input
-        char command = NULL;
+        char *command = NULL;
         size_t size = 0;
         size_t len = getline(&command, &size, stdin);
         command[len - 1] = '\0';

--- a/src/psh.cpp
+++ b/src/psh.cpp
@@ -19,8 +19,10 @@ int main()
         std::cout << std::endl << PURPLE_FOREGROUND << "○ " << std::getenv("USER") << BLUE_FOREGROUND << "→" << RESET <<" ";
 
         // Read the user input
-        char command[1024];
-        std::cin.getline(command, 1024);
+        char command = NULL;
+        size_t size = 0;
+        size_t len = getline(&command, &size, stdin);
+        command[len - 1] = '\0';
 
         // Check for EOF (Ctrl+D)
         if(std::cin.eof())


### PR DESCRIPTION
If the input is superior than 2048 characters, the program segfault

So my pull request fix it by using C-version of getline who auto allocate memory for the input buffer